### PR TITLE
avoid affecting k8s api when IE is down

### DIFF
--- a/enforcer/pkg/control/config/acconfig.go
+++ b/enforcer/pkg/control/config/acconfig.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	cfg "github.com/IBM/integrity-enforcer/enforcer/pkg/config"
+	log "github.com/sirupsen/logrus"
 )
 
 /**********************************************
@@ -65,6 +66,14 @@ func (ac *AdmissionControlConfig) InitEnforcerConfig() bool {
 		enforcerNs := os.Getenv("ENFORCER_NS")
 		enforcerConfigName := os.Getenv("ENFORCER_CONFIG_NAME")
 		enforcerConfig := LoadEnforceConfig(enforcerNs, enforcerConfigName)
+		if enforcerConfig == nil {
+			if ac.EnforcerConfig == nil {
+				log.Fatal("Failed to initialize EnforcerConfig. Exiting...")
+			} else {
+				enforcerConfig = ac.EnforcerConfig
+				log.Warn("The loaded EnforcerConfig is nil, re-use the existing one.")
+			}
+		}
 
 		chartRepo := os.Getenv("CHART_BASE_URL")
 		if chartRepo == "" {

--- a/enforcer/pkg/control/config/loader.go
+++ b/enforcer/pkg/control/config/loader.go
@@ -25,8 +25,6 @@ import (
 	cache "github.com/IBM/integrity-enforcer/enforcer/pkg/cache"
 	"github.com/IBM/integrity-enforcer/enforcer/pkg/protect"
 
-	"log"
-
 	crppapi "github.com/IBM/integrity-enforcer/enforcer/pkg/apis/clusterresourceprotectionprofile/v1alpha1"
 	rppapi "github.com/IBM/integrity-enforcer/enforcer/pkg/apis/resourceprotectionprofile/v1alpha1"
 	rsigapi "github.com/IBM/integrity-enforcer/enforcer/pkg/apis/resourcesignature/v1alpha1"
@@ -40,6 +38,8 @@ import (
 
 	ecfgclient "github.com/IBM/integrity-enforcer/enforcer/pkg/client/enforcerconfig/clientset/versioned/typed/enforcerconfig/v1alpha1"
 	cfg "github.com/IBM/integrity-enforcer/enforcer/pkg/config"
+
+	log "github.com/sirupsen/logrus"
 
 	"k8s.io/client-go/rest"
 )
@@ -408,12 +408,12 @@ func LoadEnforceConfig(namespace, cmname string) *cfg.EnforcerConfig {
 	}
 	clientset, err := ecfgclient.NewForConfig(config)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
 		return nil
 	}
 	ecres, err := clientset.EnforcerConfigs(namespace).Get(cmname, metav1.GetOptions{})
 	if err != nil {
-		log.Fatalln("failed to get EnforcerConfig:", err)
+		log.Error("failed to get EnforcerConfig:", err.Error())
 		return nil
 	}
 

--- a/operator/pkg/resources/webhook.go
+++ b/operator/pkg/resources/webhook.go
@@ -26,6 +26,8 @@ import (
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const defaultIEWebhookTimeout = 10
+
 //service
 func BuildServiceForCR(cr *researchv1alpha1.IntegrityEnforcer) *corev1.Service {
 	var targetport intstr.IntOrString
@@ -68,6 +70,7 @@ func BuildMutatingWebhookConfigurationForIE(cr *researchv1alpha1.IntegrityEnforc
 	var empty []byte
 
 	sideEffect := admv1.SideEffectClassNone
+	timeoutSeconds := int32(defaultIEWebhookTimeout)
 
 	wc := &admv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -110,7 +113,8 @@ func BuildMutatingWebhookConfigurationForIE(cr *researchv1alpha1.IntegrityEnforc
 						Rule: clusterRule,
 					},
 				},
-				SideEffects: &sideEffect,
+				SideEffects:    &sideEffect,
+				TimeoutSeconds: &timeoutSeconds,
 			},
 		},
 	}


### PR DESCRIPTION
- set 10 seconds timeout for MutatingWebhookConfiguration
- add more stable loading function for EnforcerConfig
- manage MutatingWebhookConfiguration along with IE Deoployment