### PR TITLE
use consistent attrs format for every attrs rule

### DIFF
--- a/enforcer/pkg/common/common/common.go
+++ b/enforcer/pkg/common/common/common.go
@@ -29,17 +29,9 @@ const (
 
 	SignatureCustomResourceAPIVersion = "apis.integrityenforcer.io/v1alpha1"
 	SignatureCustomResourceKind       = "ResourceSignature"
-	PolicyCustomResourceAPIVersion    = "apis.integrityenforcer.io/v1alpha1"
-	PolicyCustomResourceKind          = "EnforcePolicy"
 
-	IEPolicyCustomResourceAPIVersion      = "apis.integrityenforcer.io/v1alpha1"
-	IEPolicyCustomResourceKind            = "IntegrityEnforcerPolicy"
-	DefaultPolicyCustomResourceAPIVersion = "apis.integrityenforcer.io/v1alpha1"
-	DefaultPolicyCustomResourceKind       = "IEDefaultPolicy"
-	SignerPolicyCustomResourceAPIVersion  = "apis.integrityenforcer.io/v1alpha1"
-	SignerPolicyCustomResourceKind        = "SignPolicy"
-	AppPolicyCustomResourceAPIVersion     = "apis.integrityenforcer.io/v1alpha1"
-	AppPolicyCustomResourceKind           = "AppEnforcePolicy"
+	SignerPolicyCustomResourceAPIVersion = "apis.integrityenforcer.io/v1alpha1"
+	SignerPolicyCustomResourceKind       = "SignPolicy"
 )
 
 const (

--- a/enforcer/pkg/common/common/reqcontext.go
+++ b/enforcer/pkg/common/common/reqcontext.go
@@ -121,24 +121,8 @@ func (rc *ReqContext) IsDeleteRequest() bool {
 	return rc.Operation == "DELETE"
 }
 
-func (rc *ReqContext) IsEnforcePolicyRequest() bool {
-	return rc.GroupVersion() == PolicyCustomResourceAPIVersion && rc.Kind == PolicyCustomResourceKind
-}
-
-func (rc *ReqContext) IsIEPolicyRequest() bool {
-	return rc.GroupVersion() == IEPolicyCustomResourceAPIVersion && rc.Kind == IEPolicyCustomResourceKind
-}
-
-func (rc *ReqContext) IsIEDefaultPolicyRequest() bool {
-	return rc.GroupVersion() == DefaultPolicyCustomResourceAPIVersion && rc.Kind == DefaultPolicyCustomResourceKind
-}
-
 func (rc *ReqContext) IsSignPolicyRequest() bool {
 	return rc.GroupVersion() == SignerPolicyCustomResourceAPIVersion && rc.Kind == SignerPolicyCustomResourceKind
-}
-
-func (rc *ReqContext) IsAppEnforcePolicyRequest() bool {
-	return rc.GroupVersion() == AppPolicyCustomResourceAPIVersion && rc.Kind == AppPolicyCustomResourceKind
 }
 
 func (rc *ReqContext) IsResourceSignatureRequest() bool {

--- a/enforcer/pkg/enforcer/loader/resSigLoader.go
+++ b/enforcer/pkg/enforcer/loader/resSigLoader.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/IBM/integrity-enforcer/enforcer/pkg/common/common"
@@ -57,7 +58,7 @@ func NewResSigLoader(signatureNamespace, requestNamespace, reqApiVersion, reqKin
 		interval:           interval,
 		signatureNamespace: signatureNamespace,
 		requestNamespace:   requestNamespace,
-		reqApiVersion:      reqApiVersion,
+		reqApiVersion:      strings.ReplaceAll(reqApiVersion, "/", "_"), // `apps/v1` -> `apps_v1` because "/" cannot be used in label value
 		reqKind:            reqKind,
 		Client:             client,
 	}

--- a/enforcer/pkg/enforcer/sign/verifier.go
+++ b/enforcer/pkg/enforcer/sign/verifier.go
@@ -383,10 +383,17 @@ func matchContents(orgObj, reqObj []byte, focus, mask []string, allowDiffPattern
 	}
 
 	matched := false
-	maskedOrgNode := orgNode.Mask(mask)
-	maskedReqNode := reqNode.Mask(mask)
+	orgNodeToCompare := orgNode.Copy()
+	reqNodeToCompare := reqNode.Copy()
+	if len(focus) > 0 {
+		orgNodeToCompare = orgNode.Extract(focus)
+		reqNodeToCompare = reqNode.Extract(focus)
+	} else {
+		orgNodeToCompare = orgNode.Mask(mask)
+		reqNodeToCompare = reqNode.Mask(mask)
+	}
 
-	dr := maskedOrgNode.Diff(maskedReqNode)
+	dr := orgNodeToCompare.Diff(reqNodeToCompare)
 	if dr != nil && len(allowDiffPatterns) > 0 {
 		dr = dr.Remove(allowDiffPatterns)
 	}
@@ -394,12 +401,6 @@ func matchContents(orgObj, reqObj []byte, focus, mask []string, allowDiffPattern
 
 	if dr == nil {
 		matched = true
-	} else {
-		if len(focus) > 0 {
-			if !focusKeyExistInDiffResult(focus, dr) {
-				matched = true
-			}
-		}
 	}
 
 	if !matched && dr != nil {
@@ -435,17 +436,6 @@ func GenerateMessageFromRawObj(rawObj []byte, filter, mutableAttrs string) strin
 		}
 	}
 	return message
-}
-
-func focusKeyExistInDiffResult(focus []string, dr *mapnode.DiffResult) bool {
-	for _, diffFullKey := range dr.Keys() {
-		for _, focusKey := range focus {
-			if strings.HasPrefix(diffFullKey, focusKey) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func base64decode(str string) string {

--- a/enforcer/pkg/util/mapnode/diff.go
+++ b/enforcer/pkg/util/mapnode/diff.go
@@ -18,6 +18,7 @@ package mapnode
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -87,6 +88,10 @@ func (dr *DiffResult) Remove(patterns []*Difference) *DiffResult {
 }
 
 func (dr *DiffResult) Filter(maskKeys []string) (*DiffResult, *DiffResult, []string) {
+	for i, key := range maskKeys {
+		// to match diff fields with maskKey prefix, "*" is added here
+		maskKeys[i] = fmt.Sprintf("%s*", key)
+	}
 	filtered := &DiffResult{}
 	unfiltered := &DiffResult{}
 	matchedKeys := []string{}

--- a/enforcer/pkg/util/mapnode/node.go
+++ b/enforcer/pkg/util/mapnode/node.go
@@ -241,7 +241,8 @@ func (n *Node) Merge(n2 *Node) (*Node, error) {
 	return emptyNode(), errors.New("Unsupported type of node.")
 }
 
-func (n *Node) Filter(filterKeys []string) *Node {
+// extract elements that match input key
+func (n *Node) Extract(filterKeys []string) *Node {
 	m := n.Ravel()
 	allKeysInNode := []string{}
 	for k := range m {
@@ -283,6 +284,7 @@ func (n *Node) Filter(filterKeys []string) *Node {
 	return node
 }
 
+// remove elements that match input key
 func (t *Node) Mask(keys []string) *Node {
 	validKeys := t.validateKeyList(keys)
 	node := t.recursiveMask("", validKeys)
@@ -419,6 +421,7 @@ func (n *Node) GetNodeByJSONPath(jpathKey string) (*Node, bool) {
 	return foundNode, true
 }
 
+// convert key "foo[1].bar" to "foo.1.bar" and then generate actual existing keys by generateKeyList()
 func (t *Node) validateKeyList(keys []string) []string {
 	newKeys := []string{}
 	for i, key := range keys {
@@ -438,6 +441,12 @@ func (t *Node) validateKeyList(keys []string) []string {
 	return newKeys
 }
 
+func GetConcreteKeys(keys []string, n *Node) []string {
+	validatedKeyList := n.validateKeyList(keys)
+	return validatedKeyList
+}
+
+// expand input key "foo[].bar" to actual exsiting keys like ["foo.1.bar", "foo.2.bar"]
 func (t *Node) generateKeyList(concatKey string) []string {
 	if !strings.Contains(concatKey, "[]") {
 		return []string{}

--- a/enforcer/pkg/util/mapnode/node_test.go
+++ b/enforcer/pkg/util/mapnode/node_test.go
@@ -464,7 +464,7 @@ func TestNode(t *testing.T) {
 		"key1.key11",
 		"key2.1",
 	}
-	keepNode4 := testNode4.Filter(keepKeys)
+	keepNode4 := testNode4.Extract(keepKeys)
 	keepNode4JSON := keepNode4.ToJson()
 	// t.Log("10,", keepNode4JSON)
 
@@ -496,7 +496,7 @@ func TestNode(t *testing.T) {
 		"spec.template.spec.containers[0].env[1]",
 		"spec.template.spec.containers[].env[2]",
 	}
-	maskedEnvNode := deployOperatorNode.Filter(keepKeys2).Mask(mask2)
+	maskedEnvNode := deployOperatorNode.Extract(keepKeys2).Mask(mask2)
 	// maskedEnvNode := deployOperatorNode.Filter(keepKeys2)
 	// t.Log("15,", maskedEnvNode.ToYAML())
 

--- a/scripts/gpg-rs-sign.sh
+++ b/scripts/gpg-rs-sign.sh
@@ -56,7 +56,7 @@ rsigsig=`echo -e "$rsigspec" > temp-rsig.yaml; gpg -u $SIGNER --detach-sign --ar
 
 
 # name of resource signature
-resApiVer=`cat $INPUT_FILE | yq r - -j | jq -r '.apiVersion'`
+resApiVer=`cat $INPUT_FILE | yq r - -j | jq -r '.apiVersion' | sed 's/\//_/g'`
 resKind=`cat $INPUT_FILE | yq r - -j | jq -r '.kind'`
 reslowerkind=`cat $INPUT_FILE | yq r - -j | jq -r '.kind' | tr '[:upper:]' '[:lower:]'`
 resname=`cat $INPUT_FILE | yq r - -j | jq -r '.metadata.name'`


### PR DESCRIPTION
- use consistent attr rule format for ProtectAttrs, UnprotctAttrs and IgnoreAttrs
- remove some unused codes
- fix a issue related with ResourceSignature label value character ("/" cannot be used in label value)