### PR TITLE
fix logScope and add default unprotect attr

### DIFF
--- a/integrity-shield-operator/resources/default-rsp.yaml
+++ b/integrity-shield-operator/resources/default-rsp.yaml
@@ -25,7 +25,6 @@ spec:
   unprotectAttrs:
   - attrs:
     - metadata.annotations.argocd.argoproj.io/sync-wave
-    - metadata.labels.app.kubernetes.io/instance
     match:
     - kind: "*"
   ignoreRules: 

--- a/integrity-shield-operator/resources/default-rsp.yaml
+++ b/integrity-shield-operator/resources/default-rsp.yaml
@@ -25,6 +25,7 @@ spec:
   unprotectAttrs:
   - attrs:
     - metadata.annotations.argocd.argoproj.io/sync-wave
+    - metadata.labels.app.kubernetes.io/instance
     match:
     - kind: "*"
   ignoreRules: 

--- a/shield/pkg/common/profile.go
+++ b/shield/pkg/common/profile.go
@@ -50,8 +50,25 @@ type KustomizePattern struct {
 }
 
 type RequestPatternWithNamespace struct {
-	RequestPattern `json:""`
-	Namespace      *RulePattern `json:"namespace,omitempty"`
+	*RequestPattern `json:""`
+	Namespace       *RulePattern `json:"namespace,omitempty"`
+}
+
+func (self *RequestPatternWithNamespace) Match(reqFields map[string]string) bool {
+	if self.Namespace == nil && self.RequestPattern == nil {
+		return false
+	}
+	nsMatched := true
+	if self.Namespace != nil {
+		if !MatchPattern(string(*self.Namespace), reqFields["Namespace"]) {
+			nsMatched = false
+		}
+	}
+	otherMatched := true
+	if self.RequestPattern != nil {
+		otherMatched = self.RequestPattern.Match(reqFields)
+	}
+	return nsMatched && otherMatched
 }
 
 func (self *Rule) String() string {

--- a/shield/pkg/shield/config/shieldconfig.go
+++ b/shield/pkg/shield/config/shieldconfig.go
@@ -105,8 +105,8 @@ func (self *IShieldResourceCondition) IsServerResource(ref *common.ResourceRef) 
 }
 
 type LogRequestPattern struct {
-	common.RequestPatternWithNamespace `json:""`
-	LogLevel                           string `json:"logLevel,omitempty"`
+	*common.RequestPatternWithNamespace `json:""`
+	LogLevel                            string `json:"logLevel,omitempty"`
 }
 
 /**********************************************


### PR DESCRIPTION
- fix request pattern matching so that users can define `namespace: xxxx` for log scope config
- add a unprotect attr `metadata.labels.app.kubernetes.io/instance` which is automatically attached by ArgoCD