### PR TITLE
fix to avoid generating deny events while uninstalling ishiled

### DIFF
--- a/shield/pkg/shield/checkFunctions.go
+++ b/shield/pkg/shield/checkFunctions.go
@@ -97,11 +97,12 @@ func iShieldResourceCheck(reqc *common.ReqContext, config *config.ShieldConfig, 
 		ctx.IShieldResource = true
 	}
 
-	iShieldAdmin := checkIfIShieldAdminRequest(reqc, config)
-	iShieldServer := checkIfIShieldServerRequest(reqc, config)
-	iShieldOperator := checkIfIShieldOperatorRequest(reqc, config)
+	adminReq := checkIfIShieldAdminRequest(reqc, config)
+	serverReq := checkIfIShieldServerRequest(reqc, config)
+	operatorReq := checkIfIShieldOperatorRequest(reqc, config)
+	gcReq := checkIfGarbageCollectorRequest(reqc)
 
-	if (iShieldOperatorResource && iShieldAdmin) || (iShieldServerResource && (iShieldOperator || iShieldServer)) {
+	if (iShieldOperatorResource && (adminReq || gcReq)) || (iShieldServerResource && (operatorReq || serverReq || gcReq)) {
 		ctx.Allow = true
 		ctx.Verified = true
 		ctx.ReasonCode = common.REASON_ISHIELD_ADMIN

--- a/shield/pkg/shield/checkUtils.go
+++ b/shield/pkg/shield/checkUtils.go
@@ -211,15 +211,13 @@ func checkIfIShieldAdminRequest(reqc *common.ReqContext, config *config.ShieldCo
 	if config.IShieldAdminUserGroup != "" {
 		groupMatched = common.MatchPatternWithArray(config.IShieldAdminUserGroup, reqc.UserGroups)
 	}
-	// TODO: find better way to merge user input value into the default value for string attribute
-	if config.IShieldAdminUserName == "" {
-		config.IShieldAdminUserName = "system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount"
-	} else {
-		config.IShieldAdminUserName = config.IShieldAdminUserName + ",system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount"
-	}
 	userMatched := false
 	if config.IShieldAdminUserName != "" {
 		userMatched = common.MatchPattern(config.IShieldAdminUserName, reqc.UserName)
+	}
+	// TODO: delete this block after OLM SA will be added to `config.IShieldAdminUserName` in CR
+	if common.MatchPattern("system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount", reqc.UserName) {
+		userMatched = true
 	}
 	isAdmin := (groupMatched || userMatched)
 	return isAdmin

--- a/shield/pkg/shield/checkUtils.go
+++ b/shield/pkg/shield/checkUtils.go
@@ -35,9 +35,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func createAdmissionResponse(allowed bool, msg string, reqc *common.ReqContext, ctx *CheckContext) *v1beta1.AdmissionResponse {
-	// `patchBytes` will be nil if no patch
-	patchBytes := generatePatchBytes(reqc, ctx)
+func createAdmissionResponse(allowed bool, msg string, reqc *common.ReqContext, ctx *CheckContext, conf *config.ShieldConfig) *v1beta1.AdmissionResponse {
+	var patchBytes []byte
+	if conf.PatchEnabled(reqc) {
+		// `patchBytes` will be nil if no patch
+		patchBytes = generatePatchBytes(reqc, ctx)
+	}
 	responseMessage := fmt.Sprintf("%s (Request: %s)", msg, reqc.Info(nil))
 	return &v1beta1.AdmissionResponse{
 		Allowed: allowed,
@@ -208,6 +211,12 @@ func checkIfIShieldAdminRequest(reqc *common.ReqContext, config *config.ShieldCo
 	if config.IShieldAdminUserGroup != "" {
 		groupMatched = common.MatchPatternWithArray(config.IShieldAdminUserGroup, reqc.UserGroups)
 	}
+	// TODO: find better way to merge user input value into the default value for string attribute
+	if config.IShieldAdminUserName == "" {
+		config.IShieldAdminUserName = "system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount"
+	} else {
+		config.IShieldAdminUserName = config.IShieldAdminUserName + ",system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount"
+	}
 	userMatched := false
 	if config.IShieldAdminUserName != "" {
 		userMatched = common.MatchPattern(config.IShieldAdminUserName, reqc.UserName)
@@ -222,6 +231,11 @@ func checkIfIShieldServerRequest(reqc *common.ReqContext, config *config.ShieldC
 
 func checkIfIShieldOperatorRequest(reqc *common.ReqContext, config *config.ShieldConfig) bool {
 	return common.ExactMatch(config.IShieldResourceCondition.OperatorServiceAccount, reqc.UserName) //"service account for integrity-shield-operator"
+}
+
+func checkIfGarbageCollectorRequest(reqc *common.ReqContext) bool {
+	// TODO: should be configurable?
+	return reqc.UserName == "system:serviceaccount:kube-system:generic-garbage-collector"
 }
 
 func getBreakGlassConditions(signerConfig *sigconfapi.SignerConfig) []common.BreakGlassCondition {

--- a/shield/pkg/shield/config/shieldconfig.go
+++ b/shield/pkg/shield/config/shieldconfig.go
@@ -152,7 +152,7 @@ func (sc *LogScopeConfig) IsInScope(reqc *common.ReqContext) (bool, string) {
 
 func (ec *ShieldConfig) PatchEnabled(reqc *common.ReqContext) bool {
 	// TODO: make this configurable
-	if reqc.Kind == "Policy" {
+	if reqc.Kind == "Policy" && reqc.ApiGroup == "policy.open-cluster-management.io" {
 		return false
 	}
 	if ec.Patch == nil {

--- a/shield/pkg/shield/config/shieldconfig.go
+++ b/shield/pkg/shield/config/shieldconfig.go
@@ -150,7 +150,11 @@ func (sc *LogScopeConfig) IsInScope(reqc *common.ReqContext) (bool, string) {
 	return (isInScope && !isIgnored), level
 }
 
-func (ec *ShieldConfig) PatchEnabled() bool {
+func (ec *ShieldConfig) PatchEnabled(reqc *common.ReqContext) bool {
+	// TODO: make this configurable
+	if reqc.Kind == "Policy" {
+		return false
+	}
 	if ec.Patch == nil {
 		return false
 	}

--- a/shield/pkg/shield/handler.go
+++ b/shield/pkg/shield/handler.go
@@ -65,11 +65,11 @@ func (self *Handler) Run(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 	resp := &v1beta1.AdmissionResponse{}
 
 	if dr.isUndetermined() {
-		resp = createAdmissionResponse(false, "IntegrityShield failed to decide the response for this request", self.reqc, self.ctx)
+		resp = createAdmissionResponse(false, "IntegrityShield failed to decide the response for this request", self.reqc, self.ctx, self.config)
 	} else if dr.isErrorOccurred() {
-		resp = createAdmissionResponse(false, dr.Message, self.reqc, self.ctx)
+		resp = createAdmissionResponse(false, dr.Message, self.reqc, self.ctx, self.config)
 	} else {
-		resp = createAdmissionResponse(dr.isAllowed(), dr.Message, self.reqc, self.ctx)
+		resp = createAdmissionResponse(dr.isAllowed(), dr.Message, self.reqc, self.ctx, self.config)
 	}
 
 	// log results


### PR DESCRIPTION
- avoid to patch for `Policy` request
- add kube-system garbage collector SA to allowed SA list for all IShield resources
- add OLM SA to allowed SA list for IShield Operator resources