### PR TITLE
fix ishield resource permission tp support cluster upgrade 

### DIFF
--- a/shield/pkg/shield/checkFunctions.go
+++ b/shield/pkg/shield/checkFunctions.go
@@ -101,8 +101,9 @@ func iShieldResourceCheck(reqc *common.ReqContext, config *config.ShieldConfig, 
 	serverReq := checkIfIShieldServerRequest(reqc, config)
 	operatorReq := checkIfIShieldOperatorRequest(reqc, config)
 	gcReq := checkIfGarbageCollectorRequest(reqc)
+	spSAReq := checkIfSpecialServiceAccountRequest(reqc)
 
-	if (iShieldOperatorResource && (adminReq || gcReq)) || (iShieldServerResource && (operatorReq || serverReq || gcReq)) {
+	if (iShieldOperatorResource && (adminReq || gcReq || spSAReq)) || (iShieldServerResource && (operatorReq || serverReq || gcReq || spSAReq)) {
 		ctx.Allow = true
 		ctx.Verified = true
 		ctx.ReasonCode = common.REASON_ISHIELD_ADMIN

--- a/shield/pkg/shield/checkUtils.go
+++ b/shield/pkg/shield/checkUtils.go
@@ -241,6 +241,21 @@ func checkIfGarbageCollectorRequest(reqc *common.ReqContext) bool {
 	return reqc.UserName == "system:serviceaccount:kube-system:generic-garbage-collector"
 }
 
+func checkIfSpecialServiceAccountRequest(reqc *common.ReqContext) bool {
+	// TODO: should be configurable?
+	if strings.HasPrefix(reqc.UserName, "system:serviceaccount:kube-") {
+		return true
+	} else if strings.HasPrefix(reqc.UserName, "system:serviceaccount:openshift-") {
+		return true
+	} else if strings.HasPrefix(reqc.UserName, "system:serviceaccount:openshift:") {
+		return true
+	} else if strings.HasPrefix(reqc.UserName, "system:serviceaccount:open-cluster-") {
+		return true
+	}
+
+	return false
+}
+
 func getBreakGlassConditions(signerConfig *sigconfapi.SignerConfig) []common.BreakGlassCondition {
 	conditions := []common.BreakGlassCondition{}
 	if signerConfig != nil {


### PR DESCRIPTION
- allow some SAs in special namespaces like kube-system to delete ishield resources so that ishield can keep running even after cluster upgrade