### PR TITLE
update message and event

### DIFF
--- a/integrity-shield-operator/config/samples/apis_v1alpha1_integrityshield_local.yaml
+++ b/integrity-shield-operator/config/samples/apis_v1alpha1_integrityshield_local.yaml
@@ -2,6 +2,8 @@ apiVersion: apis.integrityshield.io/v1alpha1
 kind: IntegrityShield
 metadata:
   name: integrity-shield-server
+  finalizers:
+  - cleanup.finalizers.integrityshield.io
 spec:
   namespace: integrity-shield-operator-system
   shieldConfig:

--- a/shield/pkg/common/common.go
+++ b/shield/pkg/common/common.go
@@ -467,7 +467,7 @@ var ReasonCodeMap = map[int]ReasonCode{
 		Code:    "invalid-signature",
 	},
 	REASON_NO_SIG: {
-		Message: "Signature verification is required for this request, but no signature is found. Please attach a valid signature to the annotation or by a ResourceSignature.",
+		Message: "Signature verification is required for this request, but no signature is found. Please attach a valid signature.",
 		Code:    "no-signature",
 	},
 	REASON_NO_VALID_KEYRING: {

--- a/shield/pkg/shield/checkUtils.go
+++ b/shield/pkg/shield/checkUtils.go
@@ -56,7 +56,7 @@ func createAdmissionResponse(allowed bool, msg string, reqc *common.ReqContext, 
 	return resp
 }
 
-func createOrUpdateEvent(reqc *common.ReqContext, ctx *CheckContext, sconfig *config.ShieldConfig) error {
+func createOrUpdateEvent(reqc *common.ReqContext, ctx *CheckContext, sconfig *config.ShieldConfig, denyRSP *rspapi.ResourceSigningProfile) error {
 	config, err := kubeutil.GetKubeConfig()
 	if err != nil {
 		return err
@@ -117,7 +117,11 @@ func createOrUpdateEvent(reqc *common.ReqContext, ctx *CheckContext, sconfig *co
 		evt = current
 	}
 
-	responseMessage := fmt.Sprintf("Result: %s, Reason: \"%s\", Request: %s", resultStr, ctx.Message, reqc.Info(nil))
+	rspInfo := ""
+	if denyRSP != nil {
+		rspInfo = fmt.Sprintf(" (RSP `namespace: %s, name: %s`)", denyRSP.GetNamespace(), denyRSP.GetName())
+	}
+	responseMessage := fmt.Sprintf("Result: %s, Reason: \"%s\"%s, Request: %s", resultStr, ctx.Message, rspInfo, reqc.Info(nil))
 	tmpMessage := fmt.Sprintf("[IntegrityShieldEvent] %s", responseMessage)
 	// Event.Message can have 1024 chars at most
 	if len(tmpMessage) > 1024 {

--- a/shield/pkg/shield/handler.go
+++ b/shield/pkg/shield/handler.go
@@ -154,7 +154,7 @@ func (self *Handler) Report(denyRSP *rspapi.ResourceSigningProfile) error {
 
 	var err error
 	// create/update Event
-	err = createOrUpdateEvent(self.reqc, self.ctx, self.config)
+	err = createOrUpdateEvent(self.reqc, self.ctx, self.config, denyRSP)
 	if err != nil {
 		self.requestLog.Error("Failed to create event; ", err)
 		return err

--- a/shield/pkg/shield/testdata/dr_0.json
+++ b/shield/pkg/shield/testdata/dr_0.json
@@ -1,1 +1,1 @@
-{"type":"deny","reasonCode":19,"message":"Signature verification is required for this request, but no signature is found. Please attach a valid signature to the annotation or by a ResourceSignature."}
+{"type":"deny","reasonCode":19,"message":"Signature verification is required for this request, but no signature is found. Please attach a valid signature."}


### PR DESCRIPTION
- show signature source for verification (annotation or ResourceSignature) in message
- show RSP name&namespace in IntegrityShield event if a RSP is responsible for denying
- some other fix for test