### PR TITLE
fix local CR for e2e test 

### DIFF
--- a/integrity-shield-operator/config/samples/apis_v1alpha1_integrityshield_local.yaml
+++ b/integrity-shield-operator/config/samples/apis_v1alpha1_integrityshield_local.yaml
@@ -26,7 +26,7 @@ spec:
     - name: "SampleSigner"
       keyConfig: sample-signer-keyconfig
       subjects:
-      - email: "*"
+      - email: "sample_signer@signer.com"
   keyConfig:
   - name: sample-signer-keyconfig
     secretName: keyring-secret


### PR DESCRIPTION
- use a concrete signer email for e2e test (`*` in SignerConfig causes test failure) 