### PR TITLE
enable namespace kustomize

### DIFF
--- a/shield/pkg/common/profile.go
+++ b/shield/pkg/common/profile.go
@@ -49,9 +49,10 @@ type RequestPattern struct {
 }
 
 type KustomizePattern struct {
-	Match      []*RequestPattern `json:"match,omitempty"`
-	NamePrefix *RulePattern      `json:"namePrefix,omitempty"`
-	NameSuffix *RulePattern      `json:"nameSuffix,omitempty"`
+	Match             []*RequestPattern `json:"match,omitempty"`
+	NamePrefix        *RulePattern      `json:"namePrefix,omitempty"`
+	NameSuffix        *RulePattern      `json:"nameSuffix,omitempty"`
+	OriginalNamespace *RulePattern      `json:"originalNamespace,omitempty"`
 }
 
 type RequestPatternWithNamespace struct {
@@ -192,7 +193,13 @@ func reverse(s string) string {
 	return string(runes)
 }
 
-func (self *KustomizePattern) OverrideName(ref *ResourceRef) *ResourceRef {
+func (self *KustomizePattern) Override(ref *ResourceRef) *ResourceRef {
+	ref = self.overrideName(ref)
+	ref = self.overrideNamespace(ref)
+	return ref
+}
+
+func (self *KustomizePattern) overrideName(ref *ResourceRef) *ResourceRef {
 	name := ref.Name
 	if self.NamePrefix == nil && self.NameSuffix == nil {
 		return ref
@@ -236,6 +243,18 @@ func (self *KustomizePattern) OverrideName(ref *ResourceRef) *ResourceRef {
 		}
 	}
 	ref.Name = name
+	return ref
+}
+
+func (self *KustomizePattern) overrideNamespace(ref *ResourceRef) *ResourceRef {
+	namespace := ref.Namespace
+	if self.OriginalNamespace == nil {
+		return ref
+	} else {
+		namespace = string(*self.OriginalNamespace)
+	}
+
+	ref.Namespace = namespace
 	return ref
 }
 

--- a/shield/pkg/common/profile_test.go
+++ b/shield/pkg/common/profile_test.go
@@ -111,7 +111,7 @@ func TestKustomizePattern(t *testing.T) {
 	reqc.Name = "prefix." + reqc.Name
 
 	var kust *KustomizePattern
-	kustBytes := []byte(`{"match":[{"kind":"ConfigMap"}],"namePrefix":"*."}`)
+	kustBytes := []byte(`{"match":[{"kind":"ConfigMap"}],"namePrefix":"*.","originalNamespace":"default"}`)
 	err = json.Unmarshal(kustBytes, &kust)
 	if err != nil {
 		t.Error(err)
@@ -123,7 +123,7 @@ func TestKustomizePattern(t *testing.T) {
 		return
 	}
 	rawRef := reqc.ResourceRef()
-	kustRef := kust.OverrideName(rawRef)
+	kustRef := kust.Override(rawRef)
 	if kustRef.Name != originalName {
 		t.Errorf("OverrideName() returns wrong result; expected: %s, actual: %s", originalName, kustRef.Name)
 		return

--- a/shield/pkg/shield/sign.go
+++ b/shield/pkg/shield/sign.go
@@ -184,7 +184,7 @@ func (self *ConcreteSignatureEvaluator) Eval(reqc *common.ReqContext, resSigList
 	// override ref name if there is kustomize pattern for this
 	kustPatterns := signingProfile.Kustomize(reqc.Map())
 	if len(kustPatterns) > 0 {
-		ref = kustPatterns[0].OverrideName(ref)
+		ref = kustPatterns[0].Override(ref)
 	}
 
 	// find signature

--- a/shield/pkg/shield/signVerifier.go
+++ b/shield/pkg/shield/signVerifier.go
@@ -459,7 +459,7 @@ func makeAllowDiffPatterns(reqc *common.ReqContext, kustomizeList []*common.Kust
 	name := reqc.Name
 	kustomizedName := name
 	for _, pattern := range kustomizeList {
-		newRef := pattern.OverrideName(ref)
+		newRef := pattern.Override(ref)
 		kustomizedName = newRef.Name
 	}
 	if kustomizedName == name {

--- a/shield/pkg/util/yaml/yaml.go
+++ b/shield/pkg/util/yaml/yaml.go
@@ -35,10 +35,10 @@ type ResourceInfo struct {
 
 func FindSingleYaml(message []byte, apiVersion, kind, name, namespace string) (bool, []byte) {
 	for _, ri := range ParseMessage(message) {
-		if ri.ApiVersion == apiVersion &&
-			ri.Kind == kind &&
-			ri.Name == name &&
-			(ri.Namespace == namespace || ri.Namespace == "") {
+		if common.MatchPattern(apiVersion, ri.ApiVersion) &&
+			common.MatchPattern(kind, ri.Kind) &&
+			common.MatchPattern(name, ri.Name) &&
+			(common.MatchPattern(namespace, ri.Namespace) || ri.Namespace == "") {
 			return true, ri.raw
 		}
 	}


### PR DESCRIPTION
- enable `originalNamespace` in kustomizePatterns, this can be used for the case namespace inconsistency between `message` and `request`