### PR TITLE
set preStop (& postStart) to manage finalizer & webhook correctly

### DIFF
--- a/integrity-shield-operator/Dockerfile
+++ b/integrity-shield-operator/Dockerfile
@@ -1,8 +1,12 @@
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
-RUN mkdir /ishield-op-app && mkdir /ishield-op-app/resources
+RUN mkdir /ishield-op-app && mkdir /ishield-op-app/resources && \
+    curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq-linux64 && \
+    chmod +x jq-linux64 && \
+    mv jq-linux64 /usr/local/bin/jq
 
+ADD /scripts /ishield-op-app/scripts
 ADD /resources/common-profiles /ishield-op-app/resources/common-profiles
 ADD /resources/default-ishield-cr.yaml /ishield-op-app/resources/default-ishield-cr.yaml
 ADD /resources/webhook-rules-for-roks.yaml /ishield-op-app/resources/webhook-rules-for-roks.yaml

--- a/integrity-shield-operator/config/manager/manager.yaml
+++ b/integrity-shield-operator/config/manager/manager.yaml
@@ -52,6 +52,20 @@ spec:
         readinessProbe:
           exec:
             command: ["ls"]
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - "curl -sk -X PATCH https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/apis/apis.integrityshield.io/v1alpha1/namespaces/$POD_NAMESPACE/integrityshields/integrity-shield-server -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" -H \"Content-Type: application/merge-patch+json\" -d '{\"metadata\":{\"finalizers\":[\"cleanup.finalizers.integrityshield.io\"]}}'"
+          preStop:
+            exec:
+              command:
+              - bash
+              - -c
+              - "curl -sk -X DELETE https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/ishield-webhook-config -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" && curl -sk -X PATCH https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/apis/apis.integrityshield.io/v1alpha1/namespaces/$POD_NAMESPACE/integrityshields/integrity-shield-server -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" -H \"Content-Type: application/merge-patch+json\" -d '{\"metadata\":{\"finalizers\":[]}}'"
+
         resources:
           limits:
             cpu: 500m

--- a/integrity-shield-operator/config/manager/manager.yaml
+++ b/integrity-shield-operator/config/manager/manager.yaml
@@ -55,17 +55,10 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command:
-              - bash
-              - -c
-              - "curl -sk -X PATCH https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/apis/apis.integrityshield.io/v1alpha1/namespaces/$POD_NAMESPACE/integrityshields/integrity-shield-server -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" -H \"Content-Type: application/merge-patch+json\" -d '{\"metadata\":{\"finalizers\":[\"cleanup.finalizers.integrityshield.io\"]}}'"
+              command: ["bash", "-c", "/ishield-op-app/scripts/poststart.sh || true"] # always return 0 to avoid pod crash triggered by postStart fail
           preStop:
             exec:
-              command:
-              - bash
-              - -c
-              - "curl -sk -X DELETE https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/ishield-webhook-config -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" && curl -sk -X PATCH https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/apis/apis.integrityshield.io/v1alpha1/namespaces/$POD_NAMESPACE/integrityshields/integrity-shield-server -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" -H \"Content-Type: application/merge-patch+json\" -d '{\"metadata\":{\"finalizers\":[]}}'"
-
+              command: ["/ishield-op-app/scripts/prestop.sh"]
         resources:
           limits:
             cpu: 500m

--- a/integrity-shield-operator/scripts/poststart.sh
+++ b/integrity-shield-operator/scripts/poststart.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
+K8S_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
+ISHIELD_NS=$POD_NAMESPACE
+
+# add finalizer to all Integrity Shield CRs in ISHIELD_NS
+cr_name_list=`curl -sk -X GET -H "Authorization: Bearer $TOKEN" $K8S_API_URL/apis/apis.integrityshield.io/v1alpha1/namespaces/$ISHIELD_NS/integrityshields | jq -r .items[].metadata.name`
+IFS=$'\n'
+for cr_name in $cr_name_list
+do
+    curl -sk -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/merge-patch+json" $K8S_API_URL/apis/apis.integrityshield.io/v1alpha1/namespaces/$ISHIELD_NS/integrityshields/$cr_name -d '{"metadata":{"finalizers":["cleanup.finalizers.integrityshield.io"]}}'
+done
+

--- a/integrity-shield-operator/scripts/prestop.sh
+++ b/integrity-shield-operator/scripts/prestop.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
+K8S_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
+ISHIELD_NS=$POD_NAMESPACE
+
+# delete MutatingWebhookConfiguration "ishield-webhook-config" 
+curl -sk -X DELETE -H "Authorization: Bearer $TOKEN" $K8S_API_URL/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/ishield-webhook-config
+
+# remove finalizer from all Integrity Shield CRs in ISHIELD_NS
+cr_name_list=`curl -sk -X GET -H "Authorization: Bearer $TOKEN" $K8S_API_URL/apis/apis.integrityshield.io/v1alpha1/namespaces/$ISHIELD_NS/integrityshields | jq -r .items[].metadata.name`
+IFS=$'\n'
+for cr_name in $cr_name_list
+do
+    curl -sk -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/merge-patch+json" $K8S_API_URL/apis/apis.integrityshield.io/v1alpha1/namespaces/$ISHIELD_NS/integrityshields/$cr_name -d '{"metadata":{"finalizers":[]}}'
+done
+


### PR DESCRIPTION
- add the following finalization steps to operator container by using lifecycle.preStop
  - delete Integrity Shield mutatingwebhookconfiguration when the operator container is stopping
  - delete finalizer in Integrity Shield CR when the operator container is stopping
  - add finalizer in Integrity Shield CR when the operator container has been started (to support the case that the operator container is re-deployed after deletion)