### PR TITLE
fix GOSEC G601 issue

### DIFF
--- a/integrity-shield-operator/resources/cr.go
+++ b/integrity-shield-operator/resources/cr.go
@@ -121,10 +121,12 @@ func BuildShieldConfigForIShield(cr *apiv1alpha1.IntegrityShield, scheme *runtim
 		}
 
 		for _, ir := range cr.Spec.IgnoreRules {
-			commonProfile.IgnoreRules = append(commonProfile.IgnoreRules, &ir)
+			tmpRule := ir
+			commonProfile.IgnoreRules = append(commonProfile.IgnoreRules, &tmpRule)
 		}
 		for _, ia := range cr.Spec.IgnoreAttrs {
-			commonProfile.IgnoreAttrs = append(commonProfile.IgnoreAttrs, &ia)
+			tmpAttr := ia
+			commonProfile.IgnoreAttrs = append(commonProfile.IgnoreAttrs, &tmpAttr)
 		}
 
 		ecc.Spec.ShieldConfig.CommonProfile = commonProfile


### PR DESCRIPTION
- fix GOSEC error  `G601: Implicit memory aliasing in for loop. (gosec)` in operator cr.go